### PR TITLE
fix: Deleted new codecov action from ci-cd.yml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -87,11 +87,6 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
       - name: Publish package distributions to GitHub Releases
         uses: python-semantic-release/upload-to-gh-release@main
         if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
The new action is not "failing" our workflow, but it does not appear to be working:

[2024-02-02T23:58:08.462Z] ['info'] => Project root located at: /home/runner/work/Pythoshop/Pythoshop
[2024-02-02T23:58:08.463Z] ['info'] -> No token specified or token is empty
[2024-02-02T23:58:08.471Z] ['info'] Searching for coverage files...
[2024-02-02T23:58:08.506Z] ['info'] Warning: Some files located via search were excluded from upload.
[2024-02-02T23:58:08.506Z] ['info'] If Codecov did not locate your files, please review https://docs.codecov.com/docs/supported-report-formats
[2024-02-02T23:58:08.506Z] ['error'] There was an error running the uploader: No coverage files located, please try use `-f`, or change the project root with `-R`